### PR TITLE
Add the article description length to the text label of the edit form.

### DIFF
--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -12,7 +12,7 @@
                 </div>
 
                 <div class="form-group row">
-                    <%= f.label :description, class: "col-2 col-form-label text-light" %>
+                    <%= f.label :description, "Description (#{@article.description.length})", class: "col-2 col-form-label text-light" %>
                     <div class="col-10">
                         <%= f.text_area :description, rows: 5,  class: "form-control shadow rounded mb-3", placeholder: "Description of article" %>
                     </div>


### PR DESCRIPTION
Adding the article decription length helps the user grok length validation errors. 